### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,11 +1,11 @@
-SBUS  KEYWORD1
+SBUS	KEYWORD1
 
-begin KEYWORD2
-failsafeActive KEYWORD2
-signalLossActive KEYWORD2
-getChannel  KEYWORD2
-getChannelRaw  KEYWORD2
-waitFrame KEYWORD2
+begin	KEYWORD2
+failsafeActive	KEYWORD2
+signalLossActive	KEYWORD2
+getChannel	KEYWORD2
+getChannelRaw	KEYWORD2
+waitFrame	KEYWORD2
 sbusBlocking LITERAL1
 sbusNonBlocking LITERAL1
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords